### PR TITLE
お気に入り追加機能の実装

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,15 +1,31 @@
 class LikesController < ApplicationController
+  before_action :authenticate_user!
 
   def index
-    
+    @user = User.find(params[:user_id])
+    @likes = Like.where(user_id: @user.id)
   end
 
   def create
-
+    @post = Post.find(params[:post_id])
+    @like = @post.likes.build(user_id: current_user.id)
+    @like.save
+    render :toggle
   end
 
   def destroy
-    
+    @post = Post.find(params[:post_id])
+    @like = Like.find(params[:id])
+    @like.destroy
+    @like = nil
+    # redirect_to post_path(@like.post)
+    render :toggle
+  end
+
+  private
+
+  def like_params
+    params.require(:like).permit(:user_id, :post_id)
   end
 
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,6 +10,7 @@ class PostsController < ApplicationController
   def show
     @comment = Comment.new
     @comments = Comment.where(post_id: @post.id).order(created_at: :desc)
+    @like = Like.find_by(user_id: current_user.id, post_id: @post.id)
   end
 
   def new

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,2 +1,12 @@
 module LikesHelper
+
+  # お気に入りのボタン切り替えのために生成　→　like_btnパーシャルに使用
+  def like_toggle(user, post, like)
+    if like.nil?
+      link_to "お気に入りに追加する", post_likes_path(post),method: :post,remote: true, class:"btn btn-success"
+    else
+      link_to "お気に入りから外す", post_like_path(post, like), method: :delete,remote: true, class:"btn btn-danger"
+    end
+  end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,7 +2,8 @@ class Post < ApplicationRecord
   belongs_to :user
   belongs_to :alc_category
   belongs_to :menu_category
-  has_many  :comments, dependent: :destroy
+  has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
 
   mount_uploader :image, ImageUploader
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :user_rooms, dependent: :nullify
   has_many :rooms, through: :user_rooms
   has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/comments/_index.html.erb
+++ b/app/views/comments/_index.html.erb
@@ -1,13 +1,13 @@
 
-<div class="ma-y-20 pa-l-20 font-30">
+<div class="ma-y-20 pa-x-20 font-30">
   コメント
 </div>
-
+<hr>
 <% comments.each do |comment| %>
   <% unless comment.nil? %>
-    <div class="comment-box ma-l-30 ma-y-10">
+    <div class="comment-box ma-l-30 ma-r-30 ma-y-10">
       <div class="comment-box-content" id="comment">
-        <%= comment.content %>
+        <p style="word-wrap: break-word"><%= comment.content %></p>
       </div>
       <div class="comment-box-info right">
         <span><%= link_to "@#{comment.user.name}", user_path(comment.user) %></span>     

--- a/app/views/likes/_like_btn.html.erb
+++ b/app/views/likes/_like_btn.html.erb
@@ -1,0 +1,1 @@
+<%= like_toggle(user, post, like) %>

--- a/app/views/likes/index.html.erb
+++ b/app/views/likes/index.html.erb
@@ -1,0 +1,37 @@
+<div class="container">
+  <div class="row">
+    <div class="col-4 ma-t-50">
+      <%= render "users/user_info", user: @user %>
+    </div>
+    <div class="col-8 ma-t-30">
+      <div class="title pa-20 center">
+        <h１ class="font-30">お気に入り投稿一覧</h１>
+      </div>
+      <% if @likes.any? %>
+        <% @likes.each do |like| %>     
+          <div class="post-box border pa-20 ma-y-20">
+            <div class="post-box-title">
+              <h4 class="center"><%= link_to like.post.title, post_path(like.post) %></h4>
+            </div>
+            <hr>
+            <div class="post-box-image center">
+              <%= image_tag like.post.alc_category.image.thumb300.to_s %>  x  <%= image_tag like.post.image.thumb300.to_s %>
+            </div>
+            <div class="post-box-category">
+              <p>ジャンル：<%= like.post.menu_category.name %></p>
+            </div>
+            <div class="post-box-content">
+              <%= like.post.content %>
+            </div>
+            <div class="post-box-info ma-t-10 dis-ib">
+              <span>投稿者：<%= like.post.user.name %></span><br>
+              <span>投稿日時：<%= like.post.created_at.strftime("%Y/%m/%d %H:%M") %></span>
+            </div>
+          </div>
+        <% end %>
+      <% else %>
+        <p class="ma-t-30 center">お気に入り投稿はまだありません</p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/likes/toggle.js.erb
+++ b/app/views/likes/toggle.js.erb
@@ -1,0 +1,1 @@
+$("#like_toggle").html("<%= j(render "like_btn", {user: current_user, post: @post, like: @like}) %>")

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -7,68 +7,31 @@
       <div class="title pa-20 center">
         <h１ class="font-30">投稿一覧</h１>
       </div>
-        <% if @posts.any? %>
-          <% @posts.each do |post| %>     
-            <div class="post-box border pa-20 ma-y-20">
-              <div class="post-box-title">
-                <h4 class="center"><%= link_to post.title, post_path(post) %></h4>
-              </div>
-              <hr>
-              <div class="post-box-image center">
-                <%= image_tag post.alc_category.image.thumb300.to_s %>  x  <%= image_tag post.image.thumb300.to_s %>
-              </div>
-              <div class="post-box-category">
-                <p>ジャンル：<%= post.menu_category.name %></p>
-              </div>
-              <div class="post-box-content">
-                <%= post.content %>
-              </div>
-              <div class="post-box-info ma-t-10 dis-ib">
-                <span>投稿者：<%= post.user.name %></span><br>
-                <span>投稿日時：<%= post.created_at.strftime("%Y/%m/%d %H:%M") %></span>
-              </div>
+      <% if @posts.any? %>
+        <% @posts.each do |post| %>     
+          <div class="post-box border pa-20 ma-y-20">
+            <div class="post-box-title">
+              <h4 class="center"><%= link_to post.title, post_path(post) %></h4>
             </div>
-          <% end %>
-        <% else %>
-          <p>投稿はありません</p>
+            <hr>
+            <div class="post-box-image center">
+              <%= image_tag post.alc_category.image.thumb300.to_s %>  x  <%= image_tag post.image.thumb300.to_s %>
+            </div>
+            <div class="post-box-category">
+              <p>ジャンル：<%= post.menu_category.name %></p>
+            </div>
+            <div class="post-box-content">
+              <%= post.content %>
+            </div>
+            <div class="post-box-info ma-t-10 dis-ib">
+              <span>投稿者：<%= post.user.name %></span><br>
+              <span>投稿日時：<%= post.created_at.strftime("%Y/%m/%d %H:%M") %></span>
+            </div>
+          </div>
         <% end %>
-        <div class="post-box border pa-10 ma-y-20">
-          <div class="post-box-title">
-            <h4 class="center">title</h4>
-          </div>
-          <hr>
-          <div class="post-box-image">
-            
-          </div>
-          <div class="post-box-content">
-            
-          </div>
-        </div>
-        <div class="post-box border pa-10 ma-y-20">
-          <div class="post-box-title">
-            <h4 class="center">title</h4>
-          </div>
-          <hr>
-          <div class="post-box-image">
-            
-          </div>
-          <div class="post-box-content">
-            
-          </div>
-        </div>
-        <div class="post-box border pa-10 ma-y-20">
-          <div class="post-box-title">
-            <h4 class="center">title</h4>
-          </div>
-          <hr>
-          <div class="post-box-image">
-            
-          </div>
-          <div class="post-box-content">
-            
-          </div>
-        </div>
-      <%# end %>
+      <% else %>
+        <p class="ma-t-30 center">投稿はありません</p>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -30,13 +30,17 @@
             <li class="list-group-item d-flex justify-content-between align-items-center">
               ジャンル：<%= @post.menu_category.name %>
             </li>
+            <hr>
           </ul>
-          <div id="comments_area">
-            <%= render "comments/index", comments: @comments %>
+          <div id="like_toggle" class="post-box-like right">
+            <%= render "likes/like_btn", {user: current_user, post: @post, like: @like} %>
           </div>
-          <%= render "comments/form", {comment: @comment, post: @post} %>
-        </div>    
+        </div>
+        <div id="comments_area">
+          <%= render "comments/index", comments: @comments %>
+        </div>
+        <%= render "comments/form", {comment: @comment, post: @post} %> 
       </div>
-    </>
+    </div>
   </div>
 </div>

--- a/app/views/users/_user_info.html.erb
+++ b/app/views/users/_user_info.html.erb
@@ -21,5 +21,8 @@
   </tbody>
 </table>
 <div class="center wid-70 ma-a">
-  <%= link_to "プロフィール編集", edit_user_path(user), class:"btn btn-outline-primary btn-lg " %>
+  <%= link_to "プロフィール編集", edit_user_path(user), class:"btn btn-outline-primary btn-lg wid-100" %>
+</div>
+<div class="center wid-70 ma-a ma-t-20">
+  <%= link_to "お気に入り投稿一覧", user_likes_path(user), class:"btn btn-outline-primary btn-lg wid-100" %>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -31,7 +31,7 @@
             </tbody>
           <% end %>
         <% else %>
-          <p>該当する会員は見つかりませんでした</p>
+          <p class="ma-t-30 center">該当する会員は見つかりませんでした</p>
         <% end %>
       </table>	
       <%# add paginate %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,44 +34,31 @@
       <div class="title pa-20 center">
         <h１ class="font-30">投稿一覧</h１>
       </div>
-      <%# each %>
-          <div class="post-box border pa-10 ma-y-20">
+      <% if @user.posts.any? %>
+        <% @user.posts.each do |post| %>     
+          <div class="post-box border pa-20 ma-y-20">
             <div class="post-box-title">
-              <h4 class="center">title</h4>
+              <h4 class="center"><%= link_to post.title, post_path(post) %></h4>
             </div>
             <hr>
-            <div class="post-box-image">
-              
+            <div class="post-box-image center">
+              <%= image_tag post.alc_category.image.thumb300.to_s %>  x  <%= image_tag post.image.thumb300.to_s %>
+            </div>
+            <div class="post-box-category">
+              <p>ジャンル：<%= post.menu_category.name %></p>
             </div>
             <div class="post-box-content">
-              
+              <%= post.content %>
+            </div>
+            <div class="post-box-info ma-t-10 dis-ib">
+              <span>投稿者：<%= post.user.name %></span><br>
+              <span>投稿日時：<%= post.created_at.strftime("%Y/%m/%d %H:%M") %></span>
             </div>
           </div>
-          <div class="post-box border pa-10 ma-y-20">
-            <div class="post-box-title">
-              <h4 class="center">title</h4>
-            </div>
-            <hr>
-            <div class="post-box-image">
-              
-            </div>
-            <div class="post-box-content">
-              
-            </div>
-          </div>
-          <div class="post-box border pa-10 ma-y-20">
-            <div class="post-box-title">
-              <h4 class="center">title</h4>
-            </div>
-            <hr>
-            <div class="post-box-image">
-              
-            </div>
-            <div class="post-box-content">
-              
-            </div>
-          </div>
-      <%# end %>
+        <% end %>
+      <% else %>
+        <p class="ma-t-30 center">まだ投稿はありません</p>
+      <% end %>      <%# end %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,11 @@ Rails.application.routes.draw do
     registrations: "users/registrations"
   }
   resources :users, only:[:index, :show, :edit, :update, :destroy] do
-    resources :likes, only:[:index, :create, :destroy]
+    resources :likes, only:[:index]
   end
   resources :posts do
     resources :comments, only:[:create, :update, :destroy]
+    resources :likes, only:[:create, :destroy]
   end
   resources :rooms, only:[:show, :create] do
     post 'messages/create'


### PR DESCRIPTION
#5 お気に入り機能の実装
投稿に対して、お気に入りに追加することができる。
・非同期通信を用いて、お気に入り追加できるように実装。
・自分の投稿に対しても今は行えるようになっているが、今後変更する可能性あり。

デザインに関しては、これも他の項目同様最低限のものとなっているため、修正の必要あり。